### PR TITLE
Ensure readonly, disable keyboard shortcuts

### DIFF
--- a/UI/Control/UICurveEditor.cs
+++ b/UI/Control/UICurveEditor.cs
@@ -32,6 +32,12 @@ namespace CurveEditor.UI
             }
         }
 
+        public bool allowKeyboardShortcuts
+        {
+            get { return _canvas.allowKeyboardShortcuts; }
+            set { _canvas.allowKeyboardShortcuts = value; }
+        }
+
         public bool showScrubbers
         {
             get { return _canvas.showScrubbers; }

--- a/UI/Control/UICurveEditor.cs
+++ b/UI/Control/UICurveEditor.cs
@@ -27,6 +27,7 @@ namespace CurveEditor.UI
                 canvasGroup.interactable = !value;
                 canvasGroup.blocksRaycasts = !value;
 
+                _canvas.readOnly = value;
                 _canvas.SetSelectedPoint(null);
             }
         }

--- a/UI/Control/UICurveEditorCanvas.cs
+++ b/UI/Control/UICurveEditorCanvas.cs
@@ -26,6 +26,7 @@ namespace CurveEditor.UI
         public CurveEditorPoint selectedPoint { get; private set; } = null;
         public bool allowViewDragging { get; set; } = true;
         public bool allowViewZooming { get; set; } = true;
+        public bool readOnly { get; set; }
 
         public bool showScrubbers
         {
@@ -65,7 +66,7 @@ namespace CurveEditor.UI
         {
             if (selectedPoint != null)
             {
-                if (Input.GetKeyDown(KeyCode.Delete))
+                if (!readOnly && Input.GetKeyDown(KeyCode.Delete))
                 {
                     selectedPoint.parent.DestroyPoint(selectedPoint);
                     selectedPoint.parent.SetCurveFromPoints();

--- a/UI/Control/UICurveEditorCanvas.cs
+++ b/UI/Control/UICurveEditorCanvas.cs
@@ -26,6 +26,7 @@ namespace CurveEditor.UI
         public CurveEditorPoint selectedPoint { get; private set; } = null;
         public bool allowViewDragging { get; set; } = true;
         public bool allowViewZooming { get; set; } = true;
+        public bool allowKeyboardShortcuts { get; set; } = true;
         public bool readOnly { get; set; }
 
         public bool showScrubbers
@@ -64,6 +65,8 @@ namespace CurveEditor.UI
 
         protected void Update()
         {
+            if (!allowKeyboardShortcuts) return;
+
             if (selectedPoint != null)
             {
                 if (!readOnly && Input.GetKeyDown(KeyCode.Delete))


### PR DESCRIPTION
Even though without point selection delete is safe, I'd like to allow selecting keyframes in readonly anyway later so this won't bite me.